### PR TITLE
Added support for method calls on inline arrays

### DIFF
--- a/ng2-ts.el
+++ b/ng2-ts.el
@@ -66,7 +66,9 @@
   "<\\(\\w+\\)\\(\\[\\]\\)?.*?>")
 
 (defconst ng2-ts-method-regex
-  "\\([a-zA-Z_0-9]+\\)[.]\\([a-zA-Z_0-9]+\\)([\0-\377[:nonascii:]]*")
+  (concat "\\([[]?[a-zA-Z,_0-9]+[]]?\\)"
+          "[.]\\([a-zA-Z_0-9]+\\)"
+          "([\0-\377[:nonascii:]]*")"))
 
 (defconst ng2-ts-fn-regex
   (concat


### PR DESCRIPTION
Just like the previous one, but now also works with arrays. For example `[1, 2, 3].splice(a, b)`.