### PR TITLE
Re-enabled parent keymaps from html-mode.

### DIFF
--- a/ng2-html.el
+++ b/ng2-html.el
@@ -81,7 +81,7 @@
     (,ng2-html-event-regex . (2 font-lock-builtin-face t))
     (,ng2-html-event-regex . (3 font-lock-builtin-face t))))
 
-(defvar ng2-html-map
+(defvar ng2-html-mode-map
   (let ((map (make-keymap)))
     (define-key map (kbd "C-c C-.") 'ng2-html-goto-binding)
     (define-key map (kbd "C-c C-o") 'ng2-open-counterpart)
@@ -92,7 +92,6 @@
 (define-derived-mode ng2-html-mode
   html-mode "ng2-html"
   "Major mode for Angular 2 templates"
-  (use-local-map ng2-html-map)
   (font-lock-add-keywords nil ng2-html-font-lock-keywords))
 
 ;;;###autoload


### PR DESCRIPTION
I noticed that the keymaps from the parent html-mode were not working (eg C-c /, sgml-close-tag). Updated ng2-html.el to re-enabled them by removing the use-local-map call, and made minor rename to the map name. This is consistent with what is in ng2-ts.el already, and the docs from gnu.org