### PR TITLE
Fixed endless loop in syntax highlighting for lambdas

### DIFF
--- a/ng2-ts.el
+++ b/ng2-ts.el
@@ -197,6 +197,8 @@
                                    "\\(?:\\s-*=\\s-*.*?\\(?:[,})]\\|\\]\\)\\)?")
                            (min bound (ng2-ts--end-of-lambda-args (point))) 1))
       (and (ignore-errors
+             ;; Fix endless loop on generic return types
+             (save-match-data (while (looking-at ">") (forward-char)))
              ;; Skip forward if we wind up in the space between the args and the =>
              (ng2-ts--skip-whitespace)
              (forward-char 2)


### PR DESCRIPTION
Fixes #21 

Syntax highlighting in lambda signatures incorrectly advances the cursor position if the given return type contains generic types (ie. a `>`). In this case, the pointer gets stuck on this character, and loops indefinitely. This fix advances over any `>` that may occur after (=at the end of) the signature. The problem could probably be fixed by adjusting some regexes, but this seems to work, and shouldn't introduce any other problems as far as I'm aware.